### PR TITLE
feat(client): タスクポーリングと再開機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,8 @@ Currently, this is a minimal proof-of-concept (PoC) implementation that connects
 ### 1. ✅ Streaming Support (Server-Sent Events: SSE)
 *   **Accomplished:** Switched to the `POST /message:stream` endpoint and implemented real-time event parsing using `eventsource-parser`. Progress and artifacts are surfaced to the CLI as they arrive.
 
-### 2. Task Polling & Continuation [High Priority]
-*   **Current State:** Successfully handles `TASK_STATE_WORKING` and waits for a terminal state (`COMPLETED` or `FAILED`) within the stream.
-*   **Next Steps:**
-    *   Implement fallback polling using `GET /tasks/{id}` for environments where long-lived HTTP streams are unstable or restricted.
-    *   Handle task re-attachment (subscribing to an existing task) using `POST /tasks/{id}:subscribe`.
+### 2. ✅ Task Polling & Continuation
+*   **Accomplished:** Implemented robust task continuation to handle unstable long-lived HTTP streams. The client captures the `taskId` early and, upon stream failure, attempts to re-attach via `POST /tasks/{id}:subscribe`. If streaming remains unavailable, it automatically falls back to polling via `GET /tasks/{id}` until a terminal state is reached.
 
 ### 3. Human-in-the-Loop (Input/Auth Required) [High Priority]
 *   **Current State:** Cannot handle requests for clarification or authorization from the A2A server.

--- a/docs/plans/2026-04-02-task-polling-continuation-design.md
+++ b/docs/plans/2026-04-02-task-polling-continuation-design.md
@@ -1,0 +1,50 @@
+# Task Polling & Continuation Design
+
+## Goal
+Implement robust task continuation and fallback polling for the OpenCode Gemini CLI A2A Plugin to handle unstable long-lived HTTP streams.
+This addresses "2. Task Polling & Continuation [High Priority]" from the roadmap.
+
+## Requirements
+1. If the initial `POST /message:stream` drops before a terminal state (`TASK_STATE_COMPLETED` or `TASK_STATE_FAILED`), we must recover.
+2. Recovery mechanism 1 (Re-attachment): `POST /tasks/{taskId}:subscribe`.
+3. Recovery mechanism 2 (Fallback Polling): `GET /tasks/{taskId}` for environments where streaming is strictly restricted or unstable.
+
+## Analysis & Current State
+Currently `sendA2AMessage` in `src/client.ts` opens a stream and waits for a terminal task state. If an error occurs (e.g., AbortError/Timeout or stream interruption), the promise rejects.
+The problem is that the stream might drop *after* the server has started the task and assigned a `taskId`. In the current implementation, if the stream drops, we lose track of the task completely because the `taskId` isn't bubbled up until the very end, or it throws an error.
+
+To recover, we need to extract the `taskId` as soon as it is available (e.g., via the first `statusUpdate` or `task` event).
+
+## Proposed Architecture
+1. **Capture `taskId` early:**
+   - Add an `onTaskId?: (taskId: string) => void` callback to `SendA2AMessageOptions`.
+   - Modify `sendA2AMessage` (and `subscribeToA2ATask`) to call this callback exactly once when a `taskId` is first detected from the Server-Sent Events.
+
+2. **New Functions in `src/client.ts`:**
+   - `getA2ATask(baseUrl: string, taskId: string, options?: { token?: string }): Promise<Task>`
+     Sends `GET /tasks/{taskId}` and returns the task object.
+   - `subscribeToA2ATask(baseUrl: string, taskId: string, options?: SendA2AMessageOptions): Promise<StreamResponse>`
+     Sends `POST /tasks/{taskId}:subscribe` (SSE) and processes it identically to `sendA2AMessage`.
+
+3. **Fallback/Retry Logic in `execute` (in `src/index.ts`):**
+   - The plugin's `delegate_to_gemini` tool will maintain a `currentTaskId`.
+   - It will pass `onTaskId: (id) => currentTaskId = id`.
+   - If `sendA2AMessage` throws (e.g., network error or timeout) and we have a `currentTaskId`:
+     - **Attempt Subscribe:** We try to `subscribeToA2ATask`. If that works and streams to completion, great.
+     - **Attempt Polling:** If `subscribe` fails (e.g., stream gets aborted immediately due to network proxy not supporting SSE), we fallback to polling:
+       - Loop `getA2ATask` every 2000ms until `task.status.state` is `TASK_STATE_COMPLETED` or `TASK_STATE_FAILED`.
+       - Polling will not trigger `onProgress` for intermediate text chunks easily without fetching artifacts, so it acts as a robust degraded experience.
+
+## Interface Changes
+`src/a2a-types.ts`:
+- No new types needed.
+
+`src/client.ts`:
+- Update `SendA2AMessageOptions` interface.
+- Implement and export `getA2ATask`.
+- Implement and export `subscribeToA2ATask`.
+
+## Test Strategy
+- Add unit tests for `getA2ATask` mocking the HTTP GET.
+- Add unit tests for `subscribeToA2ATask` mocking the HTTP POST SSE.
+- Add unit tests for `onTaskId` callback in `sendA2AMessage` and verify it triggers on first `statusUpdate` or `artifactUpdate`.

--- a/docs/plans/2026-04-02-task-polling-continuation-plan.md
+++ b/docs/plans/2026-04-02-task-polling-continuation-plan.md
@@ -1,0 +1,29 @@
+# Task Polling & Continuation Implementation Plan
+
+## Phase 1: Client Utilities (TDD)
+1. **Update Options**: Add `onTaskId?: (taskId: string) => void` to `SendA2AMessageOptions` in `src/client.ts`.
+2. **Implement `onTaskId`**: Modify `sendA2AMessage` to invoke `onTaskId` exactly once when `taskId` is first seen (from `statusUpdate`, `artifactUpdate`, or `task`). Add tests to verify this behavior.
+3. **Implement `getA2ATask`**:
+   - Write a test in `tests/client.test.ts` for a successful `GET /tasks/{taskId}` request returning a `Task`.
+   - Implement `getA2ATask` in `src/client.ts`.
+4. **Implement `subscribeToA2ATask`**:
+   - Write a test in `tests/client.test.ts` for a successful `POST /tasks/{taskId}:subscribe` request that streams events.
+   - Implement `subscribeToA2ATask` in `src/client.ts` (this will share much of its stream parsing logic with `sendA2AMessage`, so consider refactoring the parser into a shared helper function `processA2AStream`).
+
+## Phase 2: Plugin Integration
+1. **Modify `delegate_to_gemini` Tool**: Update the `execute` method in `src/index.ts` to manage the task execution lifecycle.
+2. **Implement Retry & Polling Loop**:
+   - Initialize `let currentTaskId: string | null = null`.
+   - Call `sendA2AMessage` with `onTaskId: (id) => currentTaskId = id`.
+   - If `sendA2AMessage` throws an error and `currentTaskId` is set:
+     - Output: `Connection lost. Attempting to re-attach to task...`
+     - Try `subscribeToA2ATask(baseUrl, currentTaskId, ...)`.
+     - If `subscribeToA2ATask` throws:
+       - Output: `Streaming failed. Falling back to polling...`
+       - Implement a while-loop calling `getA2ATask(baseUrl, currentTaskId)` every 2000ms until the state is terminal (`TASK_STATE_COMPLETED` or `TASK_STATE_FAILED`).
+3. **Handle Completion**: Ensure the final state (from stream or polling) extracts the artifacts and formats the final result for the agent appropriately.
+
+## Phase 3: Verification
+1. Run `bun run tsc --noEmit` to verify type safety.
+2. Run `bun test` to ensure all unit tests pass.
+3. Ensure no regressions in the existing stream handling behavior.

--- a/src/client.ts
+++ b/src/client.ts
@@ -125,7 +125,7 @@ async function processA2AStream(
         try {
           onTaskId(taskId);
         } catch (e) {
-          // Ignore errors from onTaskId callback
+          console.error("Error in onTaskId callback for task", taskId, e);
         }
       }
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -344,7 +344,7 @@ export async function subscribeToA2ATask(
   const timeoutMs = options?.timeoutMs ?? 120_000;
 
   const headers: Record<string, string> = {
-    "Content-Type": "application/a2a+json",
+    "Accept": "text/event-stream",
     "A2A-Version": "1.0",
   };
   if (token) {
@@ -377,7 +377,7 @@ export async function subscribeToA2ATask(
     return await processA2AStream(response, controller, options?.onProgress, options?.onTaskId);
   } catch (error: any) {
     if (error.name === "AbortError") {
-      throw new Error(`A2A Request timeout: Request took longer than ${timeoutMs}ms`);
+      throw new Error(`A2A Subscribe timeout: Request took longer than ${timeoutMs}ms`);
     }
     throw error;
   } finally {

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,23 +24,36 @@ function isValidArtifact(a: any): boolean {
   );
 }
 
-export function isValidTask(t: any): t is Task {
-  if (
-    !t ||
-    typeof t !== "object" ||
-    typeof t.id !== "string" ||
-    !t.status ||
-    typeof t.status !== "object" ||
-    !VALID_STATES.includes(t.status.state)
-  ) {
-    return false;
+export function validateTask(t: any): { valid: true; task: Task } | { valid: false; errors: string[] } {
+  const errors: string[] = [];
+  if (!t || typeof t !== "object") {
+    errors.push("not an object");
+    return { valid: false, errors };
+  }
+  if (typeof t.id !== "string") {
+    errors.push("missing or invalid 'id'");
+  }
+  if (!t.status || typeof t.status !== "object") {
+    errors.push("missing or invalid 'status'");
+  } else if (!VALID_STATES.includes(t.status.state)) {
+    errors.push(`invalid status.state '${t.status.state}'`);
   }
   if (t.artifacts !== undefined) {
-    if (!Array.isArray(t.artifacts) || !t.artifacts.every(isValidArtifact)) {
-      return false;
+    if (!Array.isArray(t.artifacts)) {
+      errors.push("artifacts is not an array");
+    } else if (!t.artifacts.every(isValidArtifact)) {
+      errors.push("failed validation in artifacts or parts");
     }
   }
-  return true;
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+  return { valid: true, task: t as Task };
+}
+
+export function isValidTask(t: any): t is Task {
+  return validateTask(t).valid;
 }
 
 export function isValidStreamResponse(obj: any): obj is StreamResponse {
@@ -431,15 +444,12 @@ export async function getA2ATask(
     }
 
     const data = await response.json();
-    if (!isValidTask(data)) {
-      if (!data || typeof data !== "object") throw new Error("Invalid task response: not an object");
-      if (typeof data.id !== "string") throw new Error("Invalid task response: missing or invalid 'id'");
-      if (!data.status || typeof data.status !== "object") throw new Error("Invalid task response: missing or invalid 'status'");
-      if (!VALID_STATES.includes(data.status.state)) throw new Error(`Invalid task response: invalid status.state '${data.status.state}'`);
-      throw new Error("Invalid task response from server: failed validation in artifacts or parts");
+    const result = validateTask(data);
+    if (!result.valid) {
+      throw new Error(`Invalid task response: ${result.errors.join(", ")}`);
     }
 
-    return data;
+    return result.task;
   } catch (error: any) {
     if (error.name === "AbortError") {
       throw new Error(`A2A GetTask timeout: Request took longer than ${timeoutMs}ms`);

--- a/src/client.ts
+++ b/src/client.ts
@@ -221,7 +221,7 @@ async function processA2AStream(
           }
         }
         if (data.message) {
-          if (data.message.taskId) {
+          if (typeof data.message.taskId === "string") {
              notifyTaskId(data.message.taskId);
           }
           if (!resolved) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import { createParser } from "eventsource-parser";
-import type { SendMessageRequest, StreamResponse } from "./a2a-types";
+import type { SendMessageRequest, StreamResponse, Task } from "./a2a-types";
 
 const VALID_STATES = [
   "TASK_STATE_PENDING",
@@ -92,7 +92,186 @@ export function isValidStreamResponse(obj: any): obj is StreamResponse {
 export interface SendA2AMessageOptions {
   token?: string;
   onProgress?: (text: string) => Promise<void> | void;
+  onTaskId?: (taskId: string) => void;
   timeoutMs?: number;
+}
+
+async function processA2AStream(
+  response: Response,
+  controller: AbortController,
+  onProgress?: (text: string) => Promise<void> | void,
+  onTaskId?: (taskId: string) => void
+): Promise<StreamResponse> {
+  if (!response.body) {
+    throw new Error("No response body");
+  }
+
+  return await new Promise<StreamResponse>((resolve, reject) => {
+    let resolved = false;
+    let terminalData: StreamResponse | null = null;
+    let streamError: any = null;
+    const progressQueue: Promise<void>[] = [];
+    let taskIdNotified = false;
+
+    const notifyTaskId = (taskId: string) => {
+      if (!taskIdNotified && onTaskId) {
+        taskIdNotified = true;
+        try {
+          onTaskId(taskId);
+        } catch (e) {
+          // Ignore errors from onTaskId callback
+        }
+      }
+    };
+
+    const parser = createParser({
+      onError(err) {
+        if (!resolved) {
+          resolved = true;
+          streamError = err;
+          controller.abort();
+        }
+      },
+      onEvent(event) {
+        if (resolved) return;
+        if (event.data === "") return;
+        let data: any;
+        try {
+          data = JSON.parse(event.data);
+          if (!isValidStreamResponse(data)) {
+            if (!resolved) {
+              resolved = true;
+              streamError = new Error("Invalid stream response: " + JSON.stringify(data));
+              controller.abort();
+            }
+            return;
+          }
+        } catch (e) {
+          if (!resolved) {
+            resolved = true;
+            streamError = new Error("Failed to parse SSE event data: " + event.data + " - " + (e instanceof Error ? e.message : String(e)));
+            controller.abort();
+          }
+          return;
+        }
+
+        if (data.artifactUpdate) {
+          notifyTaskId(data.artifactUpdate.taskId);
+          if (onProgress) {
+            const parts = data.artifactUpdate.artifact.parts;
+            if (Array.isArray(parts)) {
+              for (const part of parts) {
+                if (part.text) {
+                  try {
+                    const res = onProgress(part.text);
+                    if (res && typeof res.then === 'function') {
+                      progressQueue.push(res.catch(e => {
+                        if (!streamError) {
+                          streamError = e;
+                        }
+                        if (!resolved) {
+                          resolved = true;
+                          controller.abort();
+                        }
+                      }));
+                    }
+                  } catch (e) {
+                    if (!streamError) {
+                      streamError = e;
+                    }
+                    if (!resolved) {
+                      resolved = true;
+                      controller.abort();
+                    }
+                    return;
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        if (data.statusUpdate?.status) {
+          notifyTaskId(data.statusUpdate.taskId);
+          const state = data.statusUpdate.status.state;
+          if (state === "TASK_STATE_COMPLETED" || state === "TASK_STATE_FAILED") {
+            if (!resolved) {
+              resolved = true;
+              terminalData = data;
+              controller.abort();
+            }
+          }
+        }
+
+        if (data.task?.status) {
+          notifyTaskId(data.task.id);
+          const state = data.task.status.state;
+          if (state === "TASK_STATE_COMPLETED" || state === "TASK_STATE_FAILED") {
+            if (!resolved) {
+              resolved = true;
+              terminalData = data;
+              controller.abort();
+            }
+          }
+        }
+        if (data.message) {
+          if (data.message.taskId) {
+             notifyTaskId(data.message.taskId);
+          }
+          if (!resolved) {
+            resolved = true;
+            terminalData = data;
+            controller.abort();
+          }
+        }
+      }
+    });
+
+    const processStream = async () => {
+      try {
+        const decoder = new TextDecoder();
+        const reader = response.body!.getReader();
+        try {
+          while (true) {
+            if (resolved) break;
+            const { done, value } = await reader.read();
+            if (done) break;
+            parser.feed(decoder.decode(value, { stream: true }));
+          }
+        } finally {
+          reader.releaseLock();
+        }
+        // Final flush
+        if (!resolved) {
+          parser.feed(decoder.decode());
+          parser.reset({ consume: true });
+        }
+      } catch (e: any) {
+        if (!streamError) {
+          streamError = e;
+        }
+      }
+
+      try {
+        await Promise.all(progressQueue);
+      } catch (e) {
+        reject(e);
+        return;
+      }
+
+      if (streamError) {
+        reject(streamError);
+      } else if (terminalData) {
+        resolve(terminalData);
+      } else {
+        reject(new Error("Stream ended without a terminal event (task, statusUpdate, or message)"));
+      }
+    };
+
+    processStream().catch((err) => {
+      reject(err);
+    });
+  });
 }
 
 export async function sendA2AMessage(
@@ -105,7 +284,6 @@ export async function sendA2AMessage(
   }
 
   const token = options?.token;
-  const onProgress = options?.onProgress;
   const timeoutMs = options?.timeoutMs ?? 120_000;
 
   const headers: Record<string, string> = {
@@ -140,157 +318,7 @@ export async function sendA2AMessage(
       throw new Error(`A2A Request failed: ${response.status} ${response.statusText} - ${errorBody}`);
     }
 
-    if (!response.body) {
-      throw new Error("No response body");
-    }
-
-    return await new Promise<StreamResponse>((resolve, reject) => {
-      let resolved = false;
-      let terminalData: StreamResponse | null = null;
-      let streamError: any = null;
-      const progressQueue: Promise<void>[] = [];
-
-      const parser = createParser({
-        onError(err) {
-          if (!resolved) {
-            resolved = true;
-            streamError = err;
-            controller.abort();
-          }
-        },
-        onEvent(event) {
-          if (resolved) return;
-          if (event.data === "") return;
-          let data: any;
-          try {
-            data = JSON.parse(event.data);
-            if (!isValidStreamResponse(data)) {
-              if (!resolved) {
-                resolved = true;
-                streamError = new Error("Invalid stream response: " + JSON.stringify(data));
-                controller.abort();
-              }
-              return;
-            }
-          } catch (e) {
-            if (!resolved) {
-              resolved = true;
-              streamError = new Error("Failed to parse SSE event data: " + event.data + " - " + (e instanceof Error ? e.message : String(e)));
-              controller.abort();
-            }
-            return;
-          }
-
-          if (data.artifactUpdate && onProgress) {
-            const parts = data.artifactUpdate.artifact.parts;
-            if (Array.isArray(parts)) {
-              for (const part of parts) {
-                if (part.text) {
-                  try {
-                    const res = onProgress(part.text);
-                    if (res && typeof res.then === 'function') {
-                      progressQueue.push(res.catch(e => {
-                        if (!streamError) {
-                          streamError = e;
-                        }
-                        if (!resolved) {
-                          resolved = true;
-                          controller.abort();
-                        }
-                      }));
-                    }
-                  } catch (e) {
-                    if (!streamError) {
-                      streamError = e;
-                    }
-                    if (!resolved) {
-                      resolved = true;
-                      controller.abort();
-                    }
-                    return;
-                  }
-                }
-              }
-            }
-          }
-
-          if (data.statusUpdate?.status) {
-            const state = data.statusUpdate.status.state;
-            if (state === "TASK_STATE_COMPLETED" || state === "TASK_STATE_FAILED") {
-              if (!resolved) {
-                resolved = true;
-                terminalData = data;
-                controller.abort();
-              }
-            }
-          }
-
-          if (data.task?.status) {
-            const state = data.task.status.state;
-            if (state === "TASK_STATE_COMPLETED" || state === "TASK_STATE_FAILED") {
-              if (!resolved) {
-                resolved = true;
-                terminalData = data;
-                controller.abort();
-              }
-            }
-          }
-          if (data.message) {
-            if (!resolved) {
-              resolved = true;
-              terminalData = data;
-              controller.abort();
-            }
-          }
-        }
-      });
-
-      const processStream = async () => {
-        try {
-          const decoder = new TextDecoder();
-          const reader = response.body!.getReader();
-          try {
-            while (true) {
-              if (resolved) break;
-              const { done, value } = await reader.read();
-              if (done) break;
-              parser.feed(decoder.decode(value, { stream: true }));
-            }
-          } finally {
-            reader.releaseLock();
-          }
-          // Final flush
-          if (!resolved) {
-            parser.feed(decoder.decode());
-            parser.reset({ consume: true });
-          }
-        } catch (e: any) {
-          if (!streamError) {
-            streamError = e;
-          }
-        }
-
-        try {
-          await Promise.all(progressQueue);
-        } catch (e) {
-          reject(e);
-          return;
-        }
-
-        if (streamError) {
-          reject(streamError);
-        } else if (terminalData) {
-          resolve(terminalData);
-        } else {
-          reject(new Error("Stream ended without a terminal event (task, statusUpdate, or message)"));
-        }
-      };
-
-      processStream().catch((err) => {
-        reject(err);
-      });
-    });
-
+    return await processA2AStream(response, controller, options?.onProgress, options?.onTaskId);
   } catch (error: any) {
     if (error.name === "AbortError") {
       throw new Error(`A2A Request timeout: Request took longer than ${timeoutMs}ms`);
@@ -301,4 +329,96 @@ export async function sendA2AMessage(
       clearTimeout(timeoutId);
     }
   }
+}
+
+export async function subscribeToA2ATask(
+  baseUrl: string,
+  taskId: string,
+  options?: SendA2AMessageOptions | string
+): Promise<StreamResponse> {
+  if (typeof options === "string") {
+    options = { token: options };
+  }
+
+  const token = options?.token;
+  const timeoutMs = options?.timeoutMs ?? 120_000;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/a2a+json",
+    "A2A-Version": "1.0",
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+
+  try {
+    const response = await fetch(`${baseUrl}/tasks/${taskId}:subscribe`, {
+      method: "POST",
+      headers,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      let errorBody = "";
+      try {
+        errorBody = await response.text();
+      } catch (e: any) {
+        if (e.name === "AbortError") {
+          throw e;
+        }
+        errorBody = "Failed to read response body";
+      }
+      throw new Error(`A2A Subscribe failed: ${response.status} ${response.statusText} - ${errorBody}`);
+    }
+
+    return await processA2AStream(response, controller, options?.onProgress, options?.onTaskId);
+  } catch (error: any) {
+    if (error.name === "AbortError") {
+      throw new Error(`A2A Request timeout: Request took longer than ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export async function getA2ATask(
+  baseUrl: string,
+  taskId: string,
+  options?: { token?: string }
+): Promise<Task> {
+  const headers: Record<string, string> = {
+    "Accept": "application/a2a+json",
+    "A2A-Version": "1.0",
+  };
+  if (options?.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
+
+  const response = await fetch(`${baseUrl}/tasks/${taskId}`, {
+    method: "GET",
+    headers,
+  });
+
+  if (!response.ok) {
+    let errorBody = "";
+    try {
+      errorBody = await response.text();
+    } catch (e) {
+      errorBody = "Failed to read response body";
+    }
+    throw new Error(`A2A GetTask failed: ${response.status} ${response.statusText} - ${errorBody}`);
+  }
+
+  const data = await response.json();
+  if (!data || typeof data !== "object" || typeof data.id !== "string" || !data.status) {
+    throw new Error("Invalid task response from server");
+  }
+
+  return data as Task;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -133,7 +133,7 @@ async function processA2AStream(
     let taskIdNotified = false;
 
     const notifyTaskId = (taskId: string) => {
-      if (!taskIdNotified && onTaskId) {
+      if (!taskIdNotified && onTaskId && taskId.trim()) {
         taskIdNotified = true;
         try {
           onTaskId(taskId);

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,27 +24,33 @@ function isValidArtifact(a: any): boolean {
   );
 }
 
+export function isValidTask(t: any): t is Task {
+  if (
+    !t ||
+    typeof t !== "object" ||
+    typeof t.id !== "string" ||
+    !t.status ||
+    typeof t.status !== "object" ||
+    !VALID_STATES.includes(t.status.state)
+  ) {
+    return false;
+  }
+  if (t.artifacts !== undefined) {
+    if (!Array.isArray(t.artifacts) || !t.artifacts.every(isValidArtifact)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function isValidStreamResponse(obj: any): obj is StreamResponse {
   if (!obj || typeof obj !== "object") return false;
 
   let hasValidField = false;
 
   if ("task" in obj) {
-    const t = obj.task;
-    if (
-      !t ||
-      typeof t !== "object" ||
-      typeof t.id !== "string" ||
-      !t.status ||
-      typeof t.status !== "object" ||
-      !VALID_STATES.includes(t.status.state)
-    ) {
+    if (!isValidTask(obj.task)) {
       return false;
-    }
-    if (t.artifacts !== undefined) {
-      if (!Array.isArray(t.artifacts) || !t.artifacts.every(isValidArtifact)) {
-        return false;
-      }
     }
     hasValidField = true;
   }
@@ -355,7 +361,7 @@ export async function subscribeToA2ATask(
   const timeoutId = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
 
   try {
-    const response = await fetch(`${baseUrl}/tasks/${taskId}:subscribe`, {
+    const response = await fetch(`${baseUrl}/tasks/${encodeURIComponent(taskId)}:subscribe`, {
       method: "POST",
       headers,
       signal: controller.signal,
@@ -390,7 +396,7 @@ export async function subscribeToA2ATask(
 export async function getA2ATask(
   baseUrl: string,
   taskId: string,
-  options?: { token?: string }
+  options?: { token?: string; timeoutMs?: number }
 ): Promise<Task> {
   const headers: Record<string, string> = {
     "Accept": "application/a2a+json",
@@ -400,25 +406,48 @@ export async function getA2ATask(
     headers["Authorization"] = `Bearer ${options.token}`;
   }
 
-  const response = await fetch(`${baseUrl}/tasks/${taskId}`, {
-    method: "GET",
-    headers,
-  });
+  const timeoutMs = options?.timeoutMs ?? 120_000;
+  const controller = new AbortController();
+  const timeoutId = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
 
-  if (!response.ok) {
-    let errorBody = "";
-    try {
-      errorBody = await response.text();
-    } catch (e) {
-      errorBody = "Failed to read response body";
+  try {
+    const response = await fetch(`${baseUrl}/tasks/${encodeURIComponent(taskId)}`, {
+      method: "GET",
+      headers,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      let errorBody = "";
+      try {
+        errorBody = await response.text();
+      } catch (e: any) {
+        if (e.name === "AbortError") {
+          throw e;
+        }
+        errorBody = "Failed to read response body";
+      }
+      throw new Error(`A2A GetTask failed: ${response.status} ${response.statusText} - ${errorBody}`);
     }
-    throw new Error(`A2A GetTask failed: ${response.status} ${response.statusText} - ${errorBody}`);
-  }
 
-  const data = await response.json();
-  if (!data || typeof data !== "object" || typeof data.id !== "string" || !data.status) {
-    throw new Error("Invalid task response from server");
-  }
+    const data = await response.json();
+    if (!isValidTask(data)) {
+      if (!data || typeof data !== "object") throw new Error("Invalid task response: not an object");
+      if (typeof data.id !== "string") throw new Error("Invalid task response: missing or invalid 'id'");
+      if (!data.status || typeof data.status !== "object") throw new Error("Invalid task response: missing or invalid 'status'");
+      if (!VALID_STATES.includes(data.status.state)) throw new Error(`Invalid task response: invalid status.state '${data.status.state}'`);
+      throw new Error("Invalid task response from server: failed validation in artifacts or parts");
+    }
 
-  return data as Task;
+    return data;
+  } catch (error: any) {
+    if (error.name === "AbortError") {
+      throw new Error(`A2A GetTask timeout: Request took longer than ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type { StreamResponse, Task } from "./a2a-types";
 export const geminiA2aPlugin: Plugin = async (input, options) => {
   const baseUrl = (options?.baseUrl as string) || "http://localhost:8080";
   const token = options?.token as string | undefined;
+  const pollIntervalMs = (options?.pollIntervalMs as number) || 2000;
 
   return {
     tool: {
@@ -77,7 +78,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                     if (consecutiveErrorCount > 5) {
                       throw new Error(`Polling failed after ${consecutiveErrorCount} consecutive errors for task ${currentTaskId}`);
                     }
-                    await new Promise(resolve => setTimeout(resolve, 2000));
+                    await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
                     pollingAttempts++;
                     continue;
                   }
@@ -87,7 +88,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                     break;
                   }
                   process.stdout.write("."); // tick
-                  await new Promise(resolve => setTimeout(resolve, 2000));
+                  await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
                   pollingAttempts++;
                 }
                 process.stdout.write("\n");
@@ -95,7 +96,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
             }
 
             if (finalMessage) {
-               const resultText = finalMessage.parts.map(p => p.text ?? "").join("");
+               const resultText = (finalMessage.parts || []).map(p => p.text ?? "").join("");
                return `Gemini agent replied:\n${resultText}`;
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, tool } from "@opencode-ai/plugin";
-import { sendA2AMessage } from "./client";
+import { sendA2AMessage, subscribeToA2ATask, getA2ATask } from "./client";
+import type { StreamResponse, Task } from "./a2a-types";
 
 export const geminiA2aPlugin: Plugin = async (input, options) => {
   const baseUrl = (options?.baseUrl as string) || "http://localhost:8080";
@@ -14,29 +15,76 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
         },
         async execute({ taskDescription }) {
           try {
-            const response = await sendA2AMessage(baseUrl, {
-              message: {
-                role: "ROLE_USER",
-                parts: [{ text: taskDescription }]
-              }
-            }, {
-              token,
-              onProgress: (text) => {
-                process.stdout.write(text);
-              }
-            });
+            let currentTaskId: string | null = null;
+            let finalTask: Task | undefined;
 
-            if (response.task && response.task.status.state === "TASK_STATE_COMPLETED") {
-               const artifacts = response.task.artifacts || [];
+            try {
+              const response = await sendA2AMessage(baseUrl, {
+                message: {
+                  role: "ROLE_USER",
+                  parts: [{ text: taskDescription }]
+                }
+              }, {
+                token,
+                onProgress: (text) => {
+                  process.stdout.write(text);
+                },
+                onTaskId: (id) => {
+                  currentTaskId = id;
+                }
+              });
+              finalTask = response.task;
+            } catch (err: any) {
+              if (!currentTaskId) {
+                throw err;
+              }
+              
+              process.stdout.write("\nConnection lost. Attempting to re-attach to task...\n");
+              
+              try {
+                const subResponse = await subscribeToA2ATask(baseUrl, currentTaskId, {
+                  token,
+                  onProgress: (text) => {
+                    process.stdout.write(text);
+                  },
+                  onTaskId: (id) => {
+                    currentTaskId = id;
+                  }
+                });
+                finalTask = subResponse.task;
+              } catch (subErr: any) {
+                process.stdout.write(`\nStreaming failed (${subErr.message}). Falling back to polling...\n`);
+                
+                // Polling loop
+                while (true) {
+                  const task = await getA2ATask(baseUrl, currentTaskId, { token });
+                  if (task.status.state === "TASK_STATE_COMPLETED" || task.status.state === "TASK_STATE_FAILED") {
+                    finalTask = task;
+                    break;
+                  }
+                  process.stdout.write("."); // tick
+                  await new Promise(resolve => setTimeout(resolve, 2000));
+                }
+                process.stdout.write("\n");
+              }
+            }
+
+            // If we only got a statusUpdate but no full task, fetch the full task to get artifacts
+            if (!finalTask && currentTaskId) {
+              finalTask = await getA2ATask(baseUrl, currentTaskId, { token });
+            }
+
+            if (finalTask && finalTask.status.state === "TASK_STATE_COMPLETED") {
+               const artifacts = finalTask.artifacts || [];
                const resultText = artifacts.map(a => a.parts.map(p => p.text ?? "").join("")).join("\n");
                return `Task completed by Gemini agent. Result:\n${resultText}`;
             }
 
-            if (response.task && response.task.status.state === "TASK_STATE_FAILED") {
-              throw new Error(`Task failed on the Gemini agent side. Response: ${JSON.stringify(response)}`);
+            if (finalTask && finalTask.status.state === "TASK_STATE_FAILED") {
+              throw new Error(`Task failed on the Gemini agent side. Final task state: ${JSON.stringify(finalTask)}`);
             }
 
-            return `Task initiated, but returned unexpected state: ${JSON.stringify(response)}`;
+            return `Task initiated, but returned unexpected state. Task: ${JSON.stringify(finalTask)}`;
           } catch (error: any) {
             throw new Error(`Error delegating task to Gemini: ${error?.message || String(error)}`);
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
 
             // If we only got a statusUpdate but no full task, fetch the full task to get artifacts
             if (!finalTask && currentTaskId) {
-              finalTask = await getA2ATask(baseUrl, currentTaskId, { token });
+              finalTask = await getA2ATask(baseUrl, currentTaskId, { token, timeoutMs: 5000 });
               if (!finalTask || !finalTask.status) {
                 throw new Error(`Failed to fetch valid task for ${currentTaskId}: ${JSON.stringify(finalTask)}`);
               }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                 let pollingAttempts = 0;
                 while (true) {
                   if (pollingAttempts >= maxPollingAttempts) {
-                    throw new Error(`Polling timed out after ${maxPollingAttempts} attempts`);
+                    throw new Error(`Polling timed out after ${maxPollingAttempts} attempts for task ${currentTaskId}`);
                   }
                   const task = await getA2ATask(baseUrl, currentTaskId, { token });
                   if (task.status.state === "TASK_STATE_COMPLETED" || task.status.state === "TASK_STATE_FAILED") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
           try {
             let currentTaskId: string | null = null;
             let finalTask: Task | undefined;
+            let finalMessage: StreamResponse["message"] | undefined;
 
             try {
               const response = await sendA2AMessage(baseUrl, {
@@ -34,6 +35,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                 }
               });
               finalTask = response.task;
+              finalMessage = response.message;
             } catch (err: any) {
               if (!currentTaskId) {
                 throw err;
@@ -52,6 +54,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                   }
                 });
                 finalTask = subResponse.task;
+                finalMessage = subResponse.message;
               } catch (subErr: any) {
                 process.stdout.write(`\nStreaming failed (${subErr.message}). Falling back to polling...\n`);
                 
@@ -66,7 +69,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
 
                   let task;
                   try {
-                    task = await getA2ATask(baseUrl, currentTaskId, { token });
+                    task = await getA2ATask(baseUrl, currentTaskId, { token, timeoutMs: 5000 });
                     consecutiveErrorCount = 0;
                   } catch (e: any) {
                     consecutiveErrorCount++;
@@ -89,6 +92,11 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                 }
                 process.stdout.write("\n");
               }
+            }
+
+            if (finalMessage) {
+               const resultText = finalMessage.parts.map(p => p.text ?? "").join("");
+               return `Gemini agent replied:\n${resultText}`;
             }
 
             // If we only got a statusUpdate but no full task, fetch the full task to get artifacts

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,11 +58,27 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                 // Polling loop
                 const maxPollingAttempts = 60; // 最大2分間（60回 × 2秒）
                 let pollingAttempts = 0;
+                let consecutiveErrorCount = 0;
                 while (true) {
                   if (pollingAttempts >= maxPollingAttempts) {
                     throw new Error(`Polling timed out after ${maxPollingAttempts} attempts for task ${currentTaskId}`);
                   }
-                  const task = await getA2ATask(baseUrl, currentTaskId, { token });
+
+                  let task;
+                  try {
+                    task = await getA2ATask(baseUrl, currentTaskId, { token });
+                    consecutiveErrorCount = 0;
+                  } catch (e: any) {
+                    consecutiveErrorCount++;
+                    console.error(`\nError fetching task ${currentTaskId}: ${e.message}`);
+                    if (consecutiveErrorCount > 5) {
+                      throw new Error(`Polling failed after ${consecutiveErrorCount} consecutive errors for task ${currentTaskId}`);
+                    }
+                    await new Promise(resolve => setTimeout(resolve, 2000));
+                    pollingAttempts++;
+                    continue;
+                  }
+
                   if (task.status.state === "TASK_STATE_COMPLETED" || task.status.state === "TASK_STATE_FAILED") {
                     finalTask = task;
                     break;
@@ -78,6 +94,9 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
             // If we only got a statusUpdate but no full task, fetch the full task to get artifacts
             if (!finalTask && currentTaskId) {
               finalTask = await getA2ATask(baseUrl, currentTaskId, { token });
+              if (!finalTask || !finalTask.status) {
+                throw new Error(`Failed to fetch valid task for ${currentTaskId}: ${JSON.stringify(finalTask)}`);
+              }
             }
 
             if (finalTask && finalTask.status.state === "TASK_STATE_COMPLETED") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,12 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                 process.stdout.write(`\nStreaming failed (${subErr.message}). Falling back to polling...\n`);
                 
                 // Polling loop
+                const maxPollingAttempts = 60; // 最大2分間（60回 × 2秒）
+                let pollingAttempts = 0;
                 while (true) {
+                  if (pollingAttempts >= maxPollingAttempts) {
+                    throw new Error(`Polling timed out after ${maxPollingAttempts} attempts`);
+                  }
                   const task = await getA2ATask(baseUrl, currentTaskId, { token });
                   if (task.status.state === "TASK_STATE_COMPLETED" || task.status.state === "TASK_STATE_FAILED") {
                     finalTask = task;
@@ -64,6 +69,7 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
                   }
                   process.stdout.write("."); // tick
                   await new Promise(resolve => setTimeout(resolve, 2000));
+                  pollingAttempts++;
                 }
                 process.stdout.write("\n");
               }

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,17 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
             }
 
             if (finalTask && finalTask.status.state === "TASK_STATE_COMPLETED") {
+               if ((!finalTask.artifacts || finalTask.artifacts.length === 0) && currentTaskId) {
+                  // Perform one additional fetch to refresh canonical task artifacts
+                  try {
+                    const refreshedTask = await getA2ATask(baseUrl, currentTaskId, { token, timeoutMs: 5000 });
+                    if (refreshedTask && refreshedTask.status.state === "TASK_STATE_COMPLETED") {
+                      finalTask = refreshedTask;
+                    }
+                  } catch (e) {
+                    console.error(`Failed to refresh task ${currentTaskId} for artifacts:`, e);
+                  }
+               }
                const artifacts = finalTask.artifacts || [];
                const resultText = artifacts.map(a => a.parts.map(p => p.text ?? "").join("")).join("\n");
                return `Task completed by Gemini agent. Result:\n${resultText}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,11 +108,14 @@ export const geminiA2aPlugin: Plugin = async (input, options) => {
             }
 
             if (finalTask && finalTask.status.state === "TASK_STATE_COMPLETED") {
-               if ((!finalTask.artifacts || finalTask.artifacts.length === 0) && currentTaskId) {
+                if ((!finalTask.artifacts || finalTask.artifacts.length === 0) && currentTaskId) {
                   // Perform one additional fetch to refresh canonical task artifacts
                   try {
                     const refreshedTask = await getA2ATask(baseUrl, currentTaskId, { token, timeoutMs: 5000 });
                     if (refreshedTask && refreshedTask.status.state === "TASK_STATE_COMPLETED") {
+                      if (!refreshedTask.artifacts || refreshedTask.artifacts.length === 0) {
+                        console.warn(`[A2A] Task ${currentTaskId} refreshed but artifacts are still missing/empty. State: ${refreshedTask.status.state}`);
+                      }
                       finalTask = refreshedTask;
                     }
                   } catch (e) {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { sendA2AMessage } from "../src/client";
+import { sendA2AMessage, subscribeToA2ATask, getA2ATask } from "../src/client";
 
 test("sendA2AMessage should parse SSE stream and trigger onProgress for multiple parts", async () => {
   const server = Bun.serve({
@@ -125,7 +125,6 @@ test("sendA2AMessage throws when stream contains malformed JSON", async () => {
   });
 
   try {
-    // We now throw on invalid JSON parts instead of ignoring them.
     await expect(sendA2AMessage(`http://localhost:${server.port}`, { message: { role: "ROLE_USER", parts: [] } })).rejects.toThrow(/Failed to parse SSE event data: not a json object/);
   } finally {
     server.stop();
@@ -158,8 +157,10 @@ test("sendA2AMessage throws on timeout during stream reading", async () => {
       const stream = new ReadableStream({
         start(controller) {
           setTimeout(() => {
-            controller.enqueue(new TextEncoder().encode(`data: {"statusUpdate": {"taskId": "task-1", "status": {"state": "TASK_STATE_WORKING"}}}\n\n`));
-            controller.close();
+            try {
+              controller.enqueue(new TextEncoder().encode(`data: {"statusUpdate": {"taskId": "task-1", "status": {"state": "TASK_STATE_WORKING"}}}\n\n`));
+              controller.close();
+            } catch (e) {}
           }, 100);
         }
       });
@@ -169,6 +170,97 @@ test("sendA2AMessage throws on timeout during stream reading", async () => {
 
   try {
     await expect(sendA2AMessage(`http://localhost:${server.port}`, { message: { role: "ROLE_USER", parts: [] } }, { timeoutMs: 50 })).rejects.toThrow("A2A Request timeout: Request took longer than 50ms");
+  } finally {
+    server.stop();
+  }
+});
+
+test("sendA2AMessage should call onTaskId when taskId is first seen", async () => {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(`data: {"statusUpdate": {"taskId": "task-abc", "status": {"state": "TASK_STATE_WORKING"}}}\n\n`));
+          controller.enqueue(new TextEncoder().encode(`data: {"statusUpdate": {"taskId": "task-abc", "status": {"state": "TASK_STATE_COMPLETED"}}}\n\n`));
+          controller.close();
+        }
+      });
+      return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+
+  try {
+    let capturedTaskId = "";
+    let callCount = 0;
+    await sendA2AMessage(
+      `http://localhost:${server.port}`,
+      { message: { role: "ROLE_USER", parts: [] } },
+      {
+        onTaskId: (id) => {
+          capturedTaskId = id;
+          callCount++;
+        }
+      }
+    );
+    expect(capturedTaskId).toBe("task-abc");
+    expect(callCount).toBe(1); // Should only be called once
+  } finally {
+    server.stop();
+  }
+});
+
+test("subscribeToA2ATask should process stream successfully", async () => {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.method === "POST" && new URL(req.url).pathname === "/tasks/task-123:subscribe") {
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`data: {"statusUpdate": {"taskId": "task-123", "status": {"state": "TASK_STATE_COMPLETED"}}}\n\n`));
+            controller.close();
+          }
+        });
+        return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+      }
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+
+  try {
+    let capturedTaskId = "";
+    const result = await subscribeToA2ATask(
+      `http://localhost:${server.port}`,
+      "task-123",
+      {
+        onTaskId: (id) => { capturedTaskId = id; }
+      }
+    );
+    expect(result.statusUpdate?.status.state).toBe("TASK_STATE_COMPLETED");
+    expect(capturedTaskId).toBe("task-123");
+  } finally {
+    server.stop();
+  }
+});
+
+test("getA2ATask should fetch task successfully", async () => {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.method === "GET" && new URL(req.url).pathname === "/tasks/task-456") {
+        return new Response(JSON.stringify({
+          id: "task-456",
+          status: { state: "TASK_STATE_WORKING" }
+        }), { headers: { "Content-Type": "application/json" } });
+      }
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+
+  try {
+    const task = await getA2ATask(`http://localhost:${server.port}`, "task-456");
+    expect(task.id).toBe("task-456");
+    expect(task.status.state).toBe("TASK_STATE_WORKING");
   } finally {
     server.stop();
   }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -330,3 +330,31 @@ test("sendA2AMessage should accept string taskId in message and call onTaskId", 
     server.stop();
   }
 });
+
+test("sendA2AMessage should ignore empty or whitespace taskId and call onTaskId only with first real ID", async () => {
+  let capturedTaskIds: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"statusUpdate": {"taskId": "  ", "status": {"state": "TASK_STATE_WORKING"}}}\n\n'));
+          controller.enqueue(new TextEncoder().encode('data: {"statusUpdate": {"taskId": "", "status": {"state": "TASK_STATE_WORKING"}}}\n\n'));
+          controller.enqueue(new TextEncoder().encode('data: {"statusUpdate": {"taskId": "task-real", "status": {"state": "TASK_STATE_WORKING"}}}\n\n'));
+          controller.enqueue(new TextEncoder().encode('data: {"statusUpdate": {"taskId": "task-ignored", "status": {"state": "TASK_STATE_COMPLETED"}}}\n\n'));
+          controller.close();
+        }
+      });
+      return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+
+  try {
+    await sendA2AMessage(`http://localhost:${server.port}`, { message: { role: "ROLE_USER", parts: [] } }, {
+      onTaskId: (id) => { capturedTaskIds.push(id); }
+    });
+    expect(capturedTaskIds).toEqual(["task-real"]);
+  } finally {
+    server.stop();
+  }
+});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -280,3 +280,53 @@ test("getA2ATask should throw on 404 response", async () => {
     server.stop();
   }
 });
+
+test("sendA2AMessage should ignore non-string taskId in message and not call onTaskId", async () => {
+  let taskIdCalled: string | null = null;
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"message": {"role": "ROLE_AGENT", "parts": [{"text": "hello"}], "taskId": 123}}\n\n'));
+          controller.close();
+        }
+      });
+      return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+
+  try {
+    await sendA2AMessage(`http://localhost:${server.port}`, { message: { role: "ROLE_USER", parts: [] } }, {
+      onTaskId: (id) => { taskIdCalled = id; }
+    });
+    expect(taskIdCalled).toBeNull();
+  } finally {
+    server.stop();
+  }
+});
+
+test("sendA2AMessage should accept string taskId in message and call onTaskId", async () => {
+  let taskIdCalled: string | null = null;
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"message": {"role": "ROLE_AGENT", "parts": [{"text": "hello"}], "taskId": "task-abc"}}\n\n'));
+          controller.close();
+        }
+      });
+      return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+
+  try {
+    await sendA2AMessage(`http://localhost:${server.port}`, { message: { role: "ROLE_USER", parts: [] } }, {
+      onTaskId: (id) => { taskIdCalled = id; }
+    });
+    expect(taskIdCalled).toBe("task-abc");
+  } finally {
+    server.stop();
+  }
+});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { sendA2AMessage, subscribeToA2ATask, getA2ATask } from "../src/client";
+import { geminiA2aPlugin } from "../src/index";
 
 test("sendA2AMessage should parse SSE stream and trigger onProgress for multiple parts", async () => {
   const server = Bun.serve({
@@ -354,6 +355,57 @@ test("sendA2AMessage should ignore empty or whitespace taskId and call onTaskId 
       onTaskId: (id) => { capturedTaskIds.push(id); }
     });
     expect(capturedTaskIds).toEqual(["task-real"]);
+  } finally {
+    server.stop();
+  }
+});
+
+test("geminiA2aPlugin should recover via polling when streaming and subscribe fail", async () => {
+  let pollCount = 0;
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/message:stream") {
+        // First request: return a statusUpdate with taskId, then fail the stream
+        const stream = new ReadableStream({
+          async start(controller) {
+            controller.enqueue(new TextEncoder().encode(`data: {"statusUpdate": {"taskId": "task-recovery", "status": {"state": "TASK_STATE_WORKING"}}}\n\n`));
+            await new Promise(r => setTimeout(r, 10)); // Give it a moment to be processed
+            controller.error(new Error("Streaming connection lost"));
+          }
+        });
+        return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+      }
+      if (url.pathname === "/tasks/task-recovery:subscribe") {
+        // Subscribe request: fail immediately
+        return new Response("Subscribe failed", { status: 500 });
+      }
+      if (url.pathname === "/tasks/task-recovery") {
+        pollCount++;
+        if (pollCount < 3) {
+          return new Response(JSON.stringify({
+            id: "task-recovery",
+            status: { state: "TASK_STATE_WORKING" }
+          }), { headers: { "Content-Type": "application/json" } });
+        } else {
+          return new Response(JSON.stringify({
+            id: "task-recovery",
+            status: { state: "TASK_STATE_COMPLETED" },
+            artifacts: [{ artifactId: "art-1", parts: [{ text: "Recovered result" }] }]
+          }), { headers: { "Content-Type": "application/json" } });
+        }
+      }
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+
+  try {
+    const plugin = await geminiA2aPlugin({}, { baseUrl: `http://localhost:${server.port}` });
+    const result = await plugin.tool.delegate_to_gemini.execute({ taskDescription: "test recovery" });
+
+    expect(pollCount).toBe(3);
+    expect(result).toBe("Task completed by Gemini agent. Result:\nRecovered result");
   } finally {
     server.stop();
   }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -401,7 +401,7 @@ test("geminiA2aPlugin should recover via polling when streaming and subscribe fa
   });
 
   try {
-    const plugin = await geminiA2aPlugin({}, { baseUrl: `http://localhost:${server.port}` });
+    const plugin = await geminiA2aPlugin({}, { baseUrl: `http://localhost:${server.port}`, pollIntervalMs: 10 });
     const result = await plugin.tool.delegate_to_gemini.execute({ taskDescription: "test recovery" });
 
     expect(pollCount).toBe(3);

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -265,3 +265,18 @@ test("getA2ATask should fetch task successfully", async () => {
     server.stop();
   }
 });
+
+test("getA2ATask should throw on 404 response", async () => {
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("Not Found", { status: 404, statusText: "Not Found" });
+    },
+  });
+  try {
+    await expect(getA2ATask(`http://localhost:${server.port}`, "no-such-task"))
+      .rejects.toThrow("A2A GetTask failed: 404 Not Found");
+  } finally {
+    server.stop();
+  }
+});


### PR DESCRIPTION
Roadmapの "2. Task Polling & Continuation" の要件を実装しました。

## 変更内容
* SSEストリームが途絶えた際のリカバリーとして、初期のイベントからtaskIdを取得する仕組みを追加。
* taskIdを用いた `POST /tasks/{id}:subscribe` による再アタッチを追加。
* 再アタッチが失敗した場合の `GET /tasks/{id}` によるフォールバックポーリングのアーキテクチャを追加。
* 関連するテストの追加と `README.md` の更新。